### PR TITLE
fix: `where` with empty object

### DIFF
--- a/lib/operator.js
+++ b/lib/operator.js
@@ -185,10 +185,10 @@ proto._where = function (where) {
     return '';
   }
 
-  let wheres = [];
-  let values = [];
+  const wheres = [];
+  const values = [];
   for (let key in where) {
-    let value = where[key];
+    const value = where[key];
     if (Array.isArray(value)) {
       wheres.push('?? IN (?)');
     } else {
@@ -197,7 +197,11 @@ proto._where = function (where) {
     values.push(key);
     values.push(value);
   }
-  return this.format(' WHERE ' + wheres.join(' AND '), values);
+  if (wheres.length > 0) {
+    return this.format(' WHERE ' + wheres.join(' AND '), values);
+  } else {
+    return '';
+  }
 };
 
 proto._selectColumns = function (table, columns) {

--- a/test/operator.test.js
+++ b/test/operator.test.js
@@ -12,6 +12,7 @@ describe('operator.test.js', function () {
     it('should get where sql', function () {
       let op = new Operator();
       assert.equal(op._where(), '');
+      assert.equal(op._where({}), '');
       assert.equal(op._where({ id: 1 }), ' WHERE `id` = 1');
       assert.equal(op._where({ id: 1, name: 'foo' }), ' WHERE `id` = 1 AND `name` = \'foo\'');
       assert.equal(op._where({ id: 1, name2: null }), ' WHERE `id` = 1 AND `name2` = NULL');

--- a/test/operator.test.js
+++ b/test/operator.test.js
@@ -11,6 +11,7 @@ describe('operator.test.js', function () {
   describe('_where(where)', function () {
     it('should get where sql', function () {
       let op = new Operator();
+      assert.equal(op._where(), '');
       assert.equal(op._where({ id: 1 }), ' WHERE `id` = 1');
       assert.equal(op._where({ id: 1, name: 'foo' }), ' WHERE `id` = 1 AND `name` = \'foo\'');
       assert.equal(op._where({ id: 1, name2: null }), ' WHERE `id` = 1 AND `name2` = NULL');


### PR DESCRIPTION
`where` 如果是一个空的 Object 时会出现错误 `ER_PARSE_ERROR: You have an error in your SQL syntax`。 因为 SQL 语句中的 `WHERE` 后面是空。