### PR TITLE
fix: `order` with empty array

### DIFF
--- a/lib/operator.js
+++ b/lib/operator.js
@@ -242,7 +242,7 @@ proto._orders = function (orders) {
       }
     }
   }
-  return ' ORDER BY ' + values.join(', ');
+  return values.length ? ' ORDER BY ' + values.join(', ') : '';
 };
 
 proto._limit = function (limit, offset) {

--- a/test/operator.test.js
+++ b/test/operator.test.js
@@ -68,4 +68,23 @@ describe('operator.test.js', function () {
       }
     });
   });
+
+  describe('_orders()', function () {
+    it('should get order sql', function* () {
+      let op = new Operator();
+      assert.equal(op._orders(), '');
+      assert.equal(op._orders([]), '');
+      assert.equal(op._orders([null]), '');
+      assert.equal(op._orders([function() {}]), '');
+      assert.equal(op._orders(['id']), ' ORDER BY `id`');
+      assert.equal(op._orders(['test.id']), ' ORDER BY `test`.`id`');
+      assert.equal(op._orders(['id', 'name']), ' ORDER BY `id`, `name`');
+      assert.equal(op._orders(['id', null]), ' ORDER BY `id`');
+      assert.equal(op._orders(['id', ['name', 'desc']]), ' ORDER BY `id`, `name` DESC');
+      assert.equal(op._orders(['id', ['name', 'ASC']]), ' ORDER BY `id`, `name` ASC');
+      assert.equal(op._orders(['id', ['name', 'other']]), ' ORDER BY `id`, `name`');
+      assert.equal(op._orders([['id', 'asc'], ['name', 'desc']]), ' ORDER BY `id` ASC, `name` DESC');
+      assert.equal(op._orders([['id', 'asc'], ['name'], 'type']), ' ORDER BY `id` ASC, `name`, `type`');
+    });
+  });
 });


### PR DESCRIPTION
If the `options.orders` is an empty array when selecting data, there will be an `ER_PARSE_ERROR: You have an error in your
SQL syntax;` error, because `Operator._orders` returns string: `" ORDER BY "`, with no attributes.

A bit similar to #15 .