### PR TITLE
fix: ignore null array in filter clause

### DIFF
--- a/lib/operator.js
+++ b/lib/operator.js
@@ -191,7 +191,10 @@ proto._where = function(where) {
   for (const key in where) {
     const value = where[key];
     if (Array.isArray(value)) {
-      wheres.push('?? IN (?)');
+      if (value.length) {
+        // ignore [], otherwise will cause mysql parser error
+        wheres.push('?? IN (?)');
+      }
     } else {
       wheres.push('?? = ?');
     }


### PR DESCRIPTION

```bash
nodejs.ER_PARSE_ERRORError: ER_PARSE_ERROR: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ') LIMIT 0, 1' at line 1
```