### PR TITLE
doc fix: 'Can\'t not' => 'Can not'

### DIFF
--- a/lib/operator.js
+++ b/lib/operator.js
@@ -149,7 +149,7 @@ proto.update = function* (table, row, options) {
   }
   if (!options.where) {
     if (!('id' in row)) {
-      throw new Error('Can\'t not auto detect update condition, please set options.where, or make sure obj.id exists');
+      throw new Error('Can not auto detect update condition, please set options.where, or make sure obj.id exists');
     }
     options.where = {
       id: row.id,

--- a/test/async.js
+++ b/test/async.js
@@ -672,7 +672,7 @@ describe('async.test.js', function() {
         throw new Error('should not run this');
       } catch (err) {
         assert.equal(err.message,
-          'Can\'t not auto detect update condition, please set options.where, or make sure obj.id exists');
+          'Can not auto detect update condition, please set options.where, or make sure obj.id exists');
       }
     });
 

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -665,7 +665,7 @@ describe('client.test.js', function() {
         throw new Error('should not run this');
       } catch (err) {
         assert.equal(err.message,
-          'Can\'t not auto detect update condition, please set options.where, or make sure obj.id exists');
+          'Can not auto detect update condition, please set options.where, or make sure obj.id exists');
       }
     });
 


### PR DESCRIPTION
closes #33 