### PR TITLE
Use "__contains" to support fuzzy search

### DIFF
--- a/lib/operator.js
+++ b/lib/operator.js
@@ -188,9 +188,13 @@ proto._where = function(where) {
 
   const wheres = [];
   const values = [];
-  for (const key in where) {
-    const value = where[key];
-    if (Array.isArray(value)) {
+  for (let key in where) {
+    let value = where[key];
+    if (key.slice(-10) === '__contains') {
+      key = key.slice(0, -10);
+      value = `%${value}%`;
+      wheres.push('?? LIKE (?)');
+    } else if (Array.isArray(value)) {
       wheres.push('?? IN (?)');
     } else {
       wheres.push('?? = ?');


### PR DESCRIPTION
many users use ali-rds orm because of the use of egg. js, but because the ali-rds support for the WHERE
 statement is not perfect, these users are troubled.