### PR TITLE
在where中使用 is null 替换 = null

### DIFF
--- a/lib/operator.js
+++ b/lib/operator.js
@@ -192,11 +192,15 @@ proto._where = function(where) {
     const value = where[key];
     if (Array.isArray(value)) {
       wheres.push('?? IN (?)');
+    } else if (value === null) {
+      wheres.push('?? IS NULL');
     } else {
       wheres.push('?? = ?');
     }
     values.push(key);
-    values.push(value);
+    if (value !== null) {
+      values.push(value);
+    }
   }
   if (wheres.length > 0) {
     return this.format(' WHERE ' + wheres.join(' AND '), values);

--- a/lib/operator.js
+++ b/lib/operator.js
@@ -192,13 +192,13 @@ proto._where = function(where) {
     const value = where[key];
     if (Array.isArray(value)) {
       wheres.push('?? IN (?)');
-    } else if (value === null) {
+    } else if (value === null || value === undefined) {
       wheres.push('?? IS NULL');
     } else {
       wheres.push('?? = ?');
     }
     values.push(key);
-    if (value !== null) {
+    if (value !== null && value !== undefined) {
       values.push(value);
     }
   }

--- a/test/operator.test.js
+++ b/test/operator.test.js
@@ -15,7 +15,7 @@ describe('operator.test.js', function() {
       assert.equal(op._where({}), '');
       assert.equal(op._where({ id: 1 }), ' WHERE `id` = 1');
       assert.equal(op._where({ id: 1, name: 'foo' }), ' WHERE `id` = 1 AND `name` = \'foo\'');
-      assert.equal(op._where({ id: 1, name2: null }), ' WHERE `id` = 1 AND `name2` = NULL');
+      assert.equal(op._where({ id: 1, name2: null }), ' WHERE `id` = 1 AND `name2` IS NULL');
       assert.equal(op._where({ 'test.id': 1 }), ' WHERE `test`.`id` = 1');
       assert.equal(op._where({ id: [ 1, 2 ], name: 'foo' }), ' WHERE `id` IN (1, 2) AND `name` = \'foo\'');
       assert.equal(op._where({ id: [ 1 ], name: 'foo' }, [ 'id', 'name' ]), ' WHERE `id` IN (1) AND `name` = \'foo\'');


### PR DESCRIPTION
mysql 中，where 语句后的 field = null 无效，应该使用 field is null