### PR TITLE
fix: add default value now() of `gmt_modified` and `gmt_create`

### DIFF
--- a/test/async.js
+++ b/test/async.js
@@ -542,7 +542,24 @@ describe('async.test.js', function() {
     });
   });
 
-  describe('insert(table, row[s])', function() {
+  describe.only('insert(table, row[s])', function() {
+    it('should set now() as a default value for `gmt_create` and `gmt_modified`', async function() {
+      const result = await this.db.insert(table, [{
+        name: prefix + 'fengmk2-insert00',
+        email: prefix + 'm@fengmk2-insert.com',
+      }, {
+        name: prefix + 'fengmk2-insert01',
+        email: prefix + 'm@fengmk2-insert.com',
+        gmt_create: this.db.literals.now,
+        gmt_modified: this.db.literals.now,
+      }]);
+      assert.equal(result.affectedRows, 2);
+
+      const result1 = await this.db.get(table, { name: prefix + 'fengmk2-insert00' }, { columns: [ 'gmt_create', 'gmt_modified' ] });
+      const result2 = await this.db.get(table, { name: prefix + 'fengmk2-insert01' }, { columns: [ 'gmt_create', 'gmt_modified' ] });
+      assert.deepEqual(result1.gmt_create, result2.gmt_create);
+      assert.deepEqual(result2.gmt_modified, result2.gmt_modified);
+    });
     it('should insert one row', async function() {
       const result = await this.db.insert(table, {
         name: prefix + 'fengmk2-insert1',

--- a/test/async.js
+++ b/test/async.js
@@ -542,7 +542,7 @@ describe('async.test.js', function() {
     });
   });
 
-  describe.only('insert(table, row[s])', function() {
+  describe('insert(table, row[s])', function() {
     it('should set now() as a default value for `gmt_create` and `gmt_modified`', async function() {
       const result = await this.db.insert(table, [{
         name: prefix + 'fengmk2-insert00',

--- a/test/rds_init.sql
+++ b/test/rds_init.sql
@@ -1,7 +1,7 @@
 CREATE TABLE IF NOT EXISTS `ali-sdk-test-user` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
- `gmt_create` datetime NOT NULL COMMENT 'create time',
- `gmt_modified` datetime NOT NULL COMMENT 'modified time',
+ `gmt_create` datetime NOT NULL COMMENT 'create time' DEFAULT NOW(),
+ `gmt_modified` datetime NOT NULL COMMENT 'modified time' DEFAULT NOW(),
  `name` varchar(100) NOT NULL COMMENT 'user name',
  `email` varchar(400) NOT NULL,
  PRIMARY KEY (`id`),


### PR DESCRIPTION
在初始化数据库的时候，设置 `gmt_modified` `gmt_create` 的默认值为 NOW()。否则跑测试用例的时候，有的 `insert` 方法没有传入 `gmt_modified` `gmt_create`：

```js
let result = await this.db.insert(table, {
        name: prefix + 'fengmk2-delete2',
        email: prefix + 'm@fengmk2-delete2.com',
 });
```

就会抛错：

```
Error: ER_NO_DEFAULT_FOR_FIELD: Field 'gmt_create' doesn't have a default value
Error: ER_NO_DEFAULT_FOR_FIELD: Field 'gmt_modified' doesn't have a default value
```
