### PR TITLE
fix: query parameters are not allowed to be included in where

### DIFF
--- a/lib/operator.js
+++ b/lib/operator.js
@@ -159,9 +159,6 @@ proto.update = function* (table, row, options) {
   const values = [];
   for (let i = 0; i < options.columns.length; i++) {
     const column = options.columns[i];
-    if (column in options.where) {
-      continue;
-    }
     sets.push('?? = ?');
     values.push(column);
     values.push(row[column]);

--- a/test/async.js
+++ b/test/async.js
@@ -722,6 +722,18 @@ describe('async.test.js', function() {
 
       try {
         result = await this.db.update(table, {
+          name: prefix + 'fengmk2-update2',
+        }, {
+          where: {
+            name: prefix + 'fengmk2-update',
+          },
+        });
+      } catch (error) {
+        assert.equal(error.message, "ER_DUP_ENTRY: Duplicate entry 'prefix-v8.11.4-fengmk2-update2' for key 'name'");
+      }
+
+      try {
+        result = await this.db.update(table, {
           name: prefix + 'fengmk2-update',
           email: prefix + 'm@fengmk2-update2.com',
           gmt_create: 'now()', // invalid date

--- a/test/async.js
+++ b/test/async.js
@@ -722,18 +722,6 @@ describe('async.test.js', function() {
 
       try {
         result = await this.db.update(table, {
-          name: prefix + 'fengmk2-update2',
-        }, {
-          where: {
-            name: prefix + 'fengmk2-update',
-          },
-        });
-      } catch (error) {
-        assert.equal(error.message, "ER_DUP_ENTRY: Duplicate entry 'prefix-v8.11.4-fengmk2-update2' for key 'name'");
-      }
-
-      try {
-        result = await this.db.update(table, {
           name: prefix + 'fengmk2-update',
           email: prefix + 'm@fengmk2-update2.com',
           gmt_create: 'now()', // invalid date

--- a/test/async.js
+++ b/test/async.js
@@ -747,10 +747,20 @@ describe('async.test.js', function() {
       });
       assert.equal(result.affectedRows, 1);
 
+      result = await this.db.update(table, {
+        email: prefix + 'm@fengmk2-update3.com',
+      }, {
+        where: {
+          name: prefix + 'fengmk2-update',
+          email: prefix + 'm@fengmk2-update2.com',
+        },
+      });
+      assert.equal(result.affectedRows, 1);
+
       user = await this.db.get(table, {
         name: prefix + 'fengmk2-update',
       });
-      assert.deepEqual(user.email, prefix + 'm@fengmk2-update2.com');
+      assert.deepEqual(user.email, prefix + 'm@fengmk2-update3.com');
       assert.deepEqual(new Date(user.gmt_create), new Date('2000'));
       assert(user.gmt_modified instanceof Date);
 


### PR DESCRIPTION
#66

不知道设计的初衷是什么？但这种情况确实是存在的且合理的。
当 查询条件等于某个值时,才允许修改某个值。

```javascript
    if (column in options.where) {	
      continue;	
    }
```

如果有其他顾虑请告知。