### PR TITLE
@guaijie support operators and support logic operation.

### DIFF
--- a/lib/operator.js
+++ b/lib/operator.js
@@ -9,6 +9,11 @@ const SqlString = require('./sqlstring');
 const literals = require('./literals');
 const wrap = require('co-wrap-all');
 
+const operators = [ 'LIKE', 'EQ', 'LTE', 'LT', 'GTE', 'GT' ];
+const toUpperCase = v => v && String.prototype.toUpperCase.call(v);
+const getType = value => Object.prototype.toString.call(value).replace(/\[object (.*)\]/, '$1');
+const JOINKEYS = [ '$and', '$or' ];
+
 module.exports = Operator;
 
 /**
@@ -309,28 +314,44 @@ proto._where = function(where) {
   if (!where) {
     return '';
   }
-
-  const wheres = [];
   const values = [];
-  for (const key in where) {
-    const value = where[key];
-    if (Array.isArray(value)) {
-      wheres.push('?? IN (?)');
-    } else {
-      if (value === null || value === undefined) {
-        wheres.push('?? IS ?');
+  const __where = (where, joinKey = '$and', recursive = false) => {
+    const wheres = [];
+    for (const key in where) {
+      let value = where[key];
+      if (JOINKEYS.includes(key)) {
+        const whereSql = __where(where[key], key, true);
+        whereSql && wheres.push(whereSql);
       } else {
-        wheres.push('?? = ?');
+        if (Array.isArray(value)) {
+          wheres.push('?? IN (?)');
+        } else if (
+          getType(value) === 'Object' && operators.includes(toUpperCase(value.operator))
+        ) {
+          wheres.push('?? ' + value.operator + ' ?');
+          value = `%${value.value}%`;
+        } else {
+          if (value === null || value === undefined) {
+            wheres.push('?? IS ?');
+          } else {
+            wheres.push('?? = ?');
+          }
+        }
+        values.push(key);
+        values.push(value);
       }
     }
-    values.push(key);
-    values.push(value);
-  }
-  if (wheres.length > 0) {
-    return this.format(' WHERE ' + wheres.join(' AND '), values);
-  }
-  return '';
+    if (recursive && wheres.length > 0) {
+      return '(' + wheres.join(' ' + joinKey.substring(1) + ' ') + ')';
+    }
+    if (!recursive && wheres.length > 0) {
+      return this.format(' WHERE ' + wheres.join(' AND '), values);
+    }
 
+    return '';
+  };
+
+  return __where(where);
 };
 
 proto._selectColumns = function(table, columns) {


### PR DESCRIPTION
support 'LIKE', 'EQ', 'LTE', 'LT', 'GTE', 'GT' operators.
example: where = {a:{value:1,oprator:'like'}}   ----->>>>  where a like '%1%'
support logic operation
example: where = {$or:{a:1,b:2}, c:3}  ----->>>> where (a = 1 or b = 2) and c =3