### PR TITLE
fix: 获取事务连接时先 await

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -117,9 +117,9 @@ export class RDSClient extends Operator {
     ctx = ctx || {};
     if (!ctx._transactionConnection) {
       // Create only one conn if concurrent call `beginTransactionScope`
-      ctx._transactionConnection = this.beginTransaction();
+      ctx._transactionConnection = await this.beginTransaction();
     }
-    const tran = await ctx._transactionConnection;
+    const tran = ctx._transactionConnection;
 
     if (!ctx._transactionScopeCount) {
       ctx._transactionScopeCount = 1;


### PR DESCRIPTION
可能导致其它使用了 ctx. _transactionConnection 的代码异常，比如 egg-dao
![image](https://github.com/ali-sdk/ali-rds/assets/3438038/7a3608e9-8d28-42e8-b491-46caf78d8bd4)
