### PR TITLE
feat: use AsyncLocalStorage to refactor transaction, to make it more safe

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "eslint": "^8.29.0",
     "eslint-config-egg": "^12.1.0",
     "git-contributor": "^2.0.0",
+    "mm": "^3.3.0",
     "typescript": "^4.9.5"
   },
   "homepage": "https://github.com/ali-sdk/ali-rds",

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,11 @@
-import type { PoolConnection } from 'mysql';
+import { AsyncLocalStorage } from 'async_hooks';
+import type { PoolConnection, PoolConfig } from 'mysql';
+import { RDSTransaction } from './transaction';
+
+export interface RDSClientOptions extends PoolConfig {
+  connectionStorageKey?: string;
+  connectionStorage?: AsyncLocalStorage<Record<PropertyKey, RDSTransaction>>;
+}
 
 export interface PoolConnectionPromisify extends Omit<PoolConnection, 'query'> {
   query(sql: string): Promise<any>;
@@ -53,3 +60,6 @@ export type LockTableOption = {
 
 export type BeforeQueryHandler = (sql: string) => string | undefined | void;
 export type AfterQueryHandler = (sql: string, result: any, execDuration: number, err?: Error) => void;
+
+export type TransactionContext = Record<PropertyKey, RDSTransaction | null>;
+export type TransactionScope = (transaction: RDSTransaction) => Promise<any>;


### PR DESCRIPTION
BREAKING CHANGE: In `Promise.all` case, Parallel beginTransactionScope will create isolated transactions.