### PR TITLE
fix: mysql type not found

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,12 +16,12 @@
     "prepublishOnly": "npm run clean && npm run build"
   },
   "dependencies": {
+    "@types/mysql": "^2.15.21",
     "mysql": "^2.18.1"
   },
   "devDependencies": {
     "@eggjs/tsconfig": "^1.3.2",
     "@types/mocha": "^10.0.1",
-    "@types/mysql": "^2.15.21",
     "@types/node": "^18.14.6",
     "egg-bin": "^6.1.2",
     "eslint": "^8.29.0",


### PR DESCRIPTION
- type `RDSClientOptions` used in the constructor inherits from type `PoolConfig` which is provided by `mysql`.
- `RDSClient.escape`, `RDSClient.escapeId`, `RDSClient.format` and `RDSClient.raw` are all implemented based on the corresponding methods in `mysql`. This means these methods need the type from `mysql`.

so maybe we need to add `@types/mysql` in dependencies, rather than devDependencies?